### PR TITLE
ops#15 Update mastersCache prematurely to close the window of inconsi…

### DIFF
--- a/cmd/dotmesh-server/pkg/main/controller.go
+++ b/cmd/dotmesh-server/pkg/main/controller.go
@@ -783,9 +783,10 @@ func (s *InMemoryState) CreateFilesystem(
 		return nil, nil, err
 	}
 
-	// TODO: update our own knowledge of mastersCache with what we just
-	// updated, so that we don't have to wait for the echo from etcd (which
-	// causes race conditions)
+	//update mastersCache with what we know
+	s.mastersCacheLock.Lock()
+	defer s.mastersCacheLock.Unlock()
+	(*s.mastersCache)[filesystemId] = s.myNodeId
 
 	// go ahead and create the filesystem
 	fs := s.initFilesystemMachine(filesystemId)


### PR DESCRIPTION
…stent state.

This is to avoid errors due to etcd/ZFS being out of sync with the data
in mastersCache.

http://gitlab.dotmesh.io:9999/dotmesh/dotmesh-sync/-/jobs/27139

with

Internal error: The volume name exists, but the volume does not (have a
master). Name:admin/volume_10 Clone:
ID:657258b5-f3eb-45d6-5520-e08634bed0ab.