### PR TITLE
Only map port if the DOTMESH_JOIN_DOCKER_NETWORK isn't another container

### DIFF
--- a/cmd/dotmesh-server/require_zfs.sh
+++ b/cmd/dotmesh-server/require_zfs.sh
@@ -182,7 +182,7 @@ if [ "$PKI_PATH" != "" ]; then
     pki_volume_mount="-v $PKI_PATH:/pki"
 fi
 
-net="-p 32607:32607 -p 32608:32608"
+net=""
 link=""
 
 # this setting means we have set DOTMESH_ETCD_ENDPOINT to a known working
@@ -223,6 +223,15 @@ fi
 if [ -n "$DOTMESH_JOIN_DOCKER_NETWORK" ]; then
     net="$net --net=$DOTMESH_JOIN_DOCKER_NETWORK"
 fi
+
+# we only add the ports if we are not using an existing container network
+case $DOTMESH_JOIN_DOCKER_NETWORK in 
+    container:*)
+        ;;
+    *)
+        net="$net -p 32607:32607 -p 32608:32608"
+        ;;
+esac
 
 secret=""
 


### PR DESCRIPTION
The `dotmesh-server` starts a `dotmesh-server-inner`, but in the case of `docker-compose`, has to tell it which network to connect to via the env var `DOTMESH_JOIN_DOCKER_NETWORK`. Since compose dynamically creates the network based on current directory name, it is pretty brittle and makes it hard to use pre-defined `docker-compose.yml` files.

Eventually, `dotmesh-server-inner` will go away, according to @binocarlos . In the meantime, it made it difficult for me to run dotscience locally.

This change still uses `DOTMESH_JOIN_DOCKER_NETWORK`, but allows you to specify `container:dotmesh-server` (or whatever the outer container is called, but specified right there in your compose file). It assumes that the `dotmesh-server` (outer) will have the ports `32607` and `32608` mapped.

When this is done, you have 3 options when running under docker:

1. Put all on the default `bridge` network (which we sometimes do anyways) - this doesn't change
2. Explicitly list the target network in the env var `DOTMESH_JOIN_DOCKER_NETWORK` (which we sometimes do anyways) - this doesn't change
3. Map ports for `dotmesh-server` and then set env var `DOTMESH_JOIN_DOCKER_NETWORK=container:dotmesh-server` and know it will inherit the right one.

Sum: Opens up new, easier option for compose or docker on its own network, without affecting backwards compatibility.

As discussed with @binocarlos 
