### PR TITLE
create volume for boltdb

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,22 @@ linux_boltdb:
     except:
         - schedules
 
+linux__restart_boltdb:
+    retry: 2
+    stage: test
+    dependencies:
+        - build_client_linux
+    tags:
+        - fast
+    script:
+        - ./test.sh -run TestRecoverFromUnmountedDotOnMasterBoltDB
+    artifacts:
+        paths:
+        - extracted_logs
+        when: always
+    except:
+        - schedules
+
 linux_single_node:
     retry: 2
     stage: test

--- a/cmd/dotmesh-server/require_zfs.sh
+++ b/cmd/dotmesh-server/require_zfs.sh
@@ -382,6 +382,7 @@ set +e
 docker run -i $rm_opt --pid=host --privileged --name=$DOTMESH_INNER_SERVER_NAME \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /run/docker/plugins:/run/docker/plugins \
+    -v dotmesh-boltdb:/data \
     -v $OUTER_DIR:$OUTER_DIR:rshared \
     -v $FLEXVOLUME_DRIVER_DIR:/system-flexvolume \
     $EXTRA_VOLUMES \


### PR DESCRIPTION
When starting dotmesh through a compose file we need to provide a volume for the inner container. 