### PR TITLE
Persist intercluster transfers to in-memory state synchronously

### DIFF
--- a/cmd/dotmesh-server/controller_fsm.go
+++ b/cmd/dotmesh-server/controller_fsm.go
@@ -100,6 +100,13 @@ func (s *InMemoryState) InitFilesystemMachine(filesystemId string) (fsm.FSM, err
 	return fs, nil
 }
 
+func (s *InMemoryState) UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult) error {
+	s.interclusterTransfersLock.Lock()
+	defer s.interclusterTransfersLock.Unlock()
+	s.interclusterTransfers[transferRequestId] = pollResult
+	return nil
+}
+
 func (s *InMemoryState) NodeID() string {
 	return s.zfs.GetPoolID()
 }

--- a/cmd/dotmesh-server/controller_fsm.go
+++ b/cmd/dotmesh-server/controller_fsm.go
@@ -100,11 +100,10 @@ func (s *InMemoryState) InitFilesystemMachine(filesystemId string) (fsm.FSM, err
 	return fs, nil
 }
 
-func (s *InMemoryState) UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult) error {
+func (s *InMemoryState) UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult) {
 	s.interclusterTransfersLock.Lock()
 	defer s.interclusterTransfersLock.Unlock()
 	s.interclusterTransfers[transferRequestId] = pollResult
-	return nil
 }
 
 func (s *InMemoryState) NodeID() string {

--- a/cmd/dotmesh-server/etcd_filesystem_watchers.go
+++ b/cmd/dotmesh-server/etcd_filesystem_watchers.go
@@ -202,8 +202,10 @@ func (s *InMemoryState) watchTransfers() error {
 			idxMax = val.Meta.ModifiedIndex
 		}
 		s.processTransferPollResults(val)
-
 	}
+
+	// ABS TEST HACK
+	idxMax = 0
 
 	return s.filesystemStore.WatchTransfers(idxMax, func(val *types.TransferPollResult) error {
 		s.processTransferPollResults(val)

--- a/cmd/dotmesh-server/etcd_filesystem_watchers.go
+++ b/cmd/dotmesh-server/etcd_filesystem_watchers.go
@@ -202,10 +202,8 @@ func (s *InMemoryState) watchTransfers() error {
 			idxMax = val.Meta.ModifiedIndex
 		}
 		s.processTransferPollResults(val)
-	}
 
-	// ABS TEST HACK
-	idxMax = 0
+	}
 
 	return s.filesystemStore.WatchTransfers(idxMax, func(val *types.TransferPollResult) error {
 		s.processTransferPollResults(val)

--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -148,7 +148,7 @@ func NewFilesystemMachine(cfg *FsConfig) *FsMachine {
 		transferUpdates: make(chan types.TransferUpdate),
 
 		filesystemMetadataTimeout: cfg.FilesystemMetadataTimeout,
-		zfs:                       zfsInter,
+		zfs: zfsInter,
 	}
 }
 
@@ -513,6 +513,13 @@ func (f *FsMachine) updateEtcdAboutTransfers() error {
 		if err != nil {
 			return err
 		}
+
+		func() {
+			s := f.state
+			s.interclusterTransfersLock.Lock()
+			defer s.interclusterTransfersLock.Unlock()
+			s.interclusterTransfers[pollResult.TransferRequestId] = pollResult
+		}()
 
 		// Go around the loop for the next command
 	}

--- a/pkg/fsm/types.go
+++ b/pkg/fsm/types.go
@@ -37,6 +37,8 @@ type StateManager interface {
 
 	RegisterNewFork(originFilesystemId, originSnapshotId, forkNamespace, forkName, forkFilesystemId string) error
 
+	UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult) error
+
 	// TODO: move under a separate interface for Etcd related things
 	MarkFilesystemAsLiveInEtcd(topLevelFilesystemId string) error
 }

--- a/pkg/fsm/types.go
+++ b/pkg/fsm/types.go
@@ -37,7 +37,7 @@ type StateManager interface {
 
 	RegisterNewFork(originFilesystemId, originSnapshotId, forkNamespace, forkName, forkFilesystemId string) error
 
-	UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult) error
+	UpdateInterclusterTransfer(transferRequestId string, pollResult types.TransferPollResult)
 
 	// TODO: move under a separate interface for Etcd related things
 	MarkFilesystemAsLiveInEtcd(topLevelFilesystemId string) error


### PR DESCRIPTION
rather than relying on some echo from a kv store to know about it locally