### PR TITLE
fail requests immediately

### DIFF
--- a/pkg/fsm/fsm_pull_initiator.go
+++ b/pkg/fsm/fsm_pull_initiator.go
@@ -262,6 +262,9 @@ func (f *FsMachine) pull(
 						"progress":     bytes,
 					},
 				}
+			default:
+				// Non-blocking read, carry on if there are no senders to
+				// disappoint.
 			}
 
 		},

--- a/pkg/fsm/fsm_push_initiator.go
+++ b/pkg/fsm/fsm_push_initiator.go
@@ -241,6 +241,9 @@ func (f *FsMachine) push(
 						"progress":     bytes,
 					},
 				}
+			default:
+				// Non-blocking read, carry on if there are no senders to
+				// disappoint.
 			}
 
 		},


### PR DESCRIPTION
... when an fsm is busy doing a potentially long-running transfer

See #684 for the issue this solves

See #683 for followup duplication cleanup