### PR TITLE
#691: until we have a better way to route zfs diff responses 

### DIFF
--- a/pkg/messaging/nats/nats_server.go
+++ b/pkg/messaging/nats/nats_server.go
@@ -27,6 +27,7 @@ func NewServer(config *Config) (*NatsServer, error) {
 	opts.Logtime = config.Logtime
 	opts.Debug = config.Debug
 	opts.Trace = config.Trace
+	opts.MaxPayload = config.MaxPayload
 
 	log.WithFields(log.Fields{
 		"port":         opts.Port,

--- a/pkg/messaging/nats/server_cfg.go
+++ b/pkg/messaging/nats/server_cfg.go
@@ -31,6 +31,7 @@ type Config struct {
 	Logtime     bool
 	Debug       bool
 	Trace       bool
+	MaxPayload  int
 }
 
 // DefaultConfig returns the default options for the messaging client & server.
@@ -43,6 +44,7 @@ func DefaultConfig() *Config {
 		Logtime:     true,
 		Debug:       true,
 		Trace:       true,
+		MaxPayload:  1073741824, // for large zfs diff results, until https://github.com/dotmesh-io/dotmesh/issues/691 is fixed
 	}
 }
 


### PR DESCRIPTION
(internal responses shouldn't go thru nats) bump the max nats payload