### PR TITLE
Fix unable to receive X@dotmesh-fastdiff: destination already exists

### DIFF
--- a/pkg/fsm/fsm_receiving.go
+++ b/pkg/fsm/fsm_receiving.go
@@ -217,5 +217,16 @@ func receivingState(f *FsMachine) StateFn {
 	if err != nil {
 		return backoffStateWithReason(fmt.Sprintf("receivingState: Error applying prelude: %+v", err))
 	}
+
+	// Clear out any tmp diff snapshot that we received by mistake
+	err = f.zfs.DestroyTmpSnapIfExists(f.filesystemId)
+	if err != nil {
+		f.innerResponses <- &types.Event{
+			Name: "cant-destroy-tmp-snap-if-exists",
+			Args: &types.EventArgs{"err": err},
+		}
+		return backoffState
+	}
+
 	return discoveringState
 }


### PR DESCRIPTION
the temporary snaps we create when doing fastdiff can accidentally end up being sent around, and when two of them get caught, there's a name collision because you can't have two snaps with the same name in zfs - fix this by deleting the snaps before we send the filesystem anywhere, and in the intra-cluster case where we can't do that because receiving is async there, at least cleaning them up after we receive a filesystem.