### PR TITLE
frontend-ng#505: enhance the rpc response for Get()

### DIFF
--- a/cmd/dotmesh-server/controller.go
+++ b/cmd/dotmesh-server/controller.go
@@ -253,6 +253,7 @@ func (s *InMemoryState) getOne(ctx context.Context, fs string) (DotmeshVolume, e
 			SizeBytes:            sizeBytes,
 			Id:                   fs,
 			CommitCount:          commitCount,
+			ServerStates:         map[string]string{},
 			ServerStatuses:       map[string]string{},
 			ForkParentId:         tlf.ForkParentId,
 			ForkParentSnapshotId: tlf.ForkParentSnapshotId,
@@ -269,19 +270,19 @@ func (s *InMemoryState) getOne(ctx context.Context, fs string) (DotmeshVolume, e
 		sort.Sort(ByAddress(servers))
 
 		if ok {
-
 			for _, server := range servers {
 				numSnapshots := len(fsm.GetSnapshots(server.Id))
 				state := fsm.GetMetadata(server.Id)
 				status := ""
 				if len(state) == 0 {
 					status = fmt.Sprintf("unknown, %d snaps", numSnapshots)
+					d.ServerStates[server.Id] = "unknown"
 				} else {
 					status = fmt.Sprintf(
-						"%s: %s, %d snaps (v%s)",
-						state["state"], state["status"],
-						numSnapshots, state["version"],
+						"%s, %d commits",
+						state["status"], numSnapshots,
 					)
+					d.ServerStates[server.Id] = state["state"]
 				}
 				d.ServerStatuses[server.Id] = status
 			}

--- a/pkg/types/volumes.go
+++ b/pkg/types/volumes.go
@@ -10,6 +10,7 @@ type DotmeshVolume struct {
 	SizeBytes            int64
 	DirtyBytes           int64
 	CommitCount          int64
+	ServerStates         map[string]string // serverId => state
 	ServerStatuses       map[string]string // serverId => status
 	ForkParentId         string
 	ForkParentSnapshotId string


### PR DESCRIPTION
and friends by:
- splitting out explicit server state e.g. active/pushPeerState from human readable description in status
- remove version as it's always zero now?
- spell human readable 'commits' as if we put this text in the UI we want it to make sense

this change is in support of https://github.com/dotmesh-io/frontend-ng/issues/505#issuecomment-500196559