### PR TITLE
fix dirty data accounting wrt fastdiff

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,8 @@ variables:
 
 stages:
     - build
-    - test
     - deploy_images
+    - test
     - deploy
     - manual_deploy
     - notify

--- a/pkg/fsm/fsm_active.go
+++ b/pkg/fsm/fsm_active.go
@@ -51,6 +51,7 @@ func activeState(f *FsMachine) StateFn {
 					Args: &types.EventArgs{"size": int64(size)},
 				}
 			}
+			f.transitionedTo("active", "predicted size")
 			return activeState
 		} else if e.Name == "transfer" {
 
@@ -271,6 +272,7 @@ func activeState(f *FsMachine) StateFn {
 			f.innerResponses <- &types.Event{
 				Name: "rolled-back",
 			}
+			f.transitionedTo("active", "rolled back")
 			return activeState
 		} else if e.Name == "clone" {
 			// clone a new filesystem from the given snapshot, then spin off a
@@ -310,12 +312,14 @@ func activeState(f *FsMachine) StateFn {
 				Name: "cloned",
 				Args: &types.EventArgs{"newFilesystemId": newCloneFilesystemId},
 			}
+			f.transitionedTo("active", "cloned")
 			return activeState
 		} else if e.Name == "mount" {
 			f.innerResponses <- &types.Event{
 				Name: "mounted",
 				Args: &types.EventArgs{},
 			}
+			f.transitionedTo("active", "mounted")
 			return activeState
 		} else if e.Name == "unmount" {
 			// fail if any containers running

--- a/pkg/fsm/fsm_active_file_io.go
+++ b/pkg/fsm/fsm_active_file_io.go
@@ -76,6 +76,7 @@ func (f *FsMachine) saveFile(file *types.InputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
+	f.transitionedTo("active", "saved file")
 	return activeState
 }
 
@@ -128,6 +129,7 @@ func (f *FsMachine) readFile(file *types.OutputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
+	f.transitionedTo("active", "read file")
 	return activeState
 }
 
@@ -157,6 +159,7 @@ func (f *FsMachine) readDirectory(file *types.OutputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
+	f.transitionedTo("active", "read directory")
 	return activeState
 
 }

--- a/pkg/fsm/fsm_active_file_io.go
+++ b/pkg/fsm/fsm_active_file_io.go
@@ -76,7 +76,6 @@ func (f *FsMachine) saveFile(file *types.InputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
-	f.transitionedTo("active", "saved file")
 	return activeState
 }
 
@@ -129,7 +128,6 @@ func (f *FsMachine) readFile(file *types.OutputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
-	f.transitionedTo("active", "read file")
 	return activeState
 }
 
@@ -159,7 +157,6 @@ func (f *FsMachine) readDirectory(file *types.OutputFile) StateFn {
 		Args: &types.EventArgs{},
 	}
 
-	f.transitionedTo("active", "read directory")
 	return activeState
 
 }

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -1086,6 +1086,9 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 		Result:     sortedResult,
 	}
 
+	// TODO delete this verbose logging
+	log.Printf("[diff] response for %s = %s", filesystemID, sortedResult)
+
 	return sortedResult, nil
 }
 

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -406,11 +406,27 @@ func (z *zfs) DeleteFilesystemInZFS(fs string) error {
 }
 
 func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, error) {
+	dirty, total, _, err := z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemId, latestSnap)
+	return dirty, total, err
+}
+
+func (z *zfs) getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemId, latestSnap string) (
+	// the bool flag returned indicates whether the tmp snapshot and the latest
+	// snapshot both have zero "used", which is a hint that they might both be
+	// using the same blocks (i.e. are same snapshot logically); in this case,
+	// the used value for both is reported as zero.  catch this case so that we
+	// can clean up the tmp snapshot in this case, otherwise dirty delta is
+	// incorrectly returned as zero, when in fact there is dirty data on the
+	// filesystem!
+	//
+	// dirty, total, tmp snap used == latest snap used == 0, err
+	int64, int64, bool, error,
+) {
 	o, err := exec.Command(
 		z.zfsPath, "get", "-pHr", "referenced,used", FQ(z.poolName, filesystemId),
 	).CombinedOutput()
 	if err != nil {
-		return 0, 0, fmt.Errorf(
+		return 0, 0, false, fmt.Errorf(
 			"[pollDirty] 'zfs get -pHr referenced,used %s' errored with: %s %s",
 			FQ(z.poolName, filesystemId), err, o,
 		)
@@ -432,24 +448,24 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 				if shrap[1] == "referenced" {
 					referDataset, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				} else if shrap[1] == "used" {
 					usedDataset, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				}
 			} else if shrap[0] == FQ(z.poolName, filesystemId)+"@"+latestSnap {
 				if shrap[1] == "referenced" {
 					referLatestSnap, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				} else if shrap[1] == "used" {
 					usedLatestSnap, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				}
 			} else if shrap[0] == FQ(z.poolName, filesystemId)+"@"+tmpSnapshotName {
@@ -457,12 +473,12 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 				if shrap[1] == "referenced" {
 					referTmpSnap, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				} else if shrap[1] == "used" {
 					usedTmpSnap, err = strconv.ParseInt(shrap[2], 10, 64)
 					if err != nil {
-						return 0, 0, err
+						return 0, 0, false, err
 					}
 				}
 			}
@@ -470,26 +486,30 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 	}
 	//        deleted                                + added
 	result := intDiff(referDataset, referLatestSnap) + usedLatestSnap
+	var checkLatestTmpSnapBothZeros bool = false
 	if foundTmpSnashot && latestSnap != tmpSnapshotName {
 		//        deleted                               added
 		result += intDiff(referDataset, referTmpSnap) + usedTmpSnap
+
+		checkLatestTmpSnapBothZeros = usedLatestSnap == 0 && usedTmpSnap == 0
 	}
 
 	log.WithFields(log.Fields{
-		"filesystemId":    filesystemId,
-		"referDataset":    referDataset,
-		"referLatestSnap": referLatestSnap,
-		"usedLatestSnap":  usedLatestSnap,
-		"foundTmpSnashot": foundTmpSnashot,
-		"latestSnap":      latestSnap,
-		"referTmpSnap":    referTmpSnap,
-		"usedTmpSnap":     usedTmpSnap,
-		"usedDataset":     usedDataset,
-		"result":          result,
+		"filesystemId":                filesystemId,
+		"referDataset":                referDataset,
+		"referLatestSnap":             referLatestSnap,
+		"usedLatestSnap":              usedLatestSnap,
+		"foundTmpSnashot":             foundTmpSnashot,
+		"latestSnap":                  latestSnap,
+		"referTmpSnap":                referTmpSnap,
+		"usedTmpSnap":                 usedTmpSnap,
+		"usedDataset":                 usedDataset,
+		"result":                      result,
+		"checkLatestTmpSnapBothZeros": checkLatestTmpSnapBothZeros,
 	}).Info("calculated dirty data")
 
-	//     delta,  total size,  error
-	return result, usedDataset, nil
+	// dirty delta, total size, checkLatestTmpSnapBothZeros, error
+	return result, usedDataset, checkLatestTmpSnapBothZeros, nil
 }
 
 func intDiff(a, b int64) int64 {
@@ -864,17 +884,39 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 	latestMnt := utils.Mnt("diff-latest-" + filesystemID)
 	tmpMnt := utils.Mnt("diff-tmp-" + filesystemID)
 
-	// First, if the dotmesh-fastdiff snapshot exists and there's no dirty data
-	// on it, and we have a cached diffResultCache, return it
+	// check if we're in the case where both the latest snapshots both have a
+	// zero "used" value. in this case, because zfs space accounting for "used"
+	// values for snapshots only reports blocks _unique_ to that snapshot,
+	// we'll fail to detect changes to the filesystem in the dirty data
+	// algorithm. in this case, we need to clean up the tmp snapshot before
+	// proceeding, otherwise we risk missing filesystem changes.
 
-	tmpExistsErr := exec.CommandContext(ctx, z.zfsPath, "get", "name", tmp).Run()
-	if tmpExistsErr == nil {
-		dirty, _, err := z.GetDirtyDelta(filesystemID, tmpSnapshotName)
+	dirty, _, checkLatestTmpSnapBothZeros, err := z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, tmpSnapshotName)
+	if err != nil {
+		log.WithError(err).Error("[diff] error get dirty delta")
+		return nil, err
+	}
+
+	if checkLatestTmpSnapBothZeros {
+		// clean up tmp snap and try again
+		exec.CommandContext(ctx, "umount", tmpMnt).Run()
+		exec.CommandContext(ctx, z.zfsPath, "destroy", tmp).Run()
+
+		dirty, _, checkLatestTmpSnapBothZeros, err = z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, tmpSnapshotName)
 		if err != nil {
-			log.WithError(err).Error("[diff] error get dirty delta")
+			log.WithError(err).Error("[diff] error get dirty delta (second try after tmp cleanup)")
 			return nil, err
 		}
 
+		if checkLatestTmpSnapBothZeros {
+			return nil, fmt.Errorf("tmp snapshot was stick around after trying to delete it")
+		}
+	}
+
+	// First, if the dotmesh-fastdiff snapshot exists and there's no dirty data
+	// on it, and we have a cached diffResultCache, return it
+	tmpExistsErr := exec.CommandContext(ctx, z.zfsPath, "get", "name", tmp).Run()
+	if tmpExistsErr == nil {
 		if dirty == 0 {
 			// try to use the cache
 			if result, ok := diffResultCache[filesystemID]; ok {
@@ -885,7 +927,7 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 		}
 	}
 
-	err := os.MkdirAll(tmpMnt, 0775)
+	err = os.MkdirAll(tmpMnt, 0775)
 	if err != nil {
 		log.WithError(err).Error("[diff] error mkdir tmpMnt")
 		return nil, err

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -474,7 +474,21 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 		//        deleted                               added
 		result += intDiff(referDataset, referTmpSnap) + usedTmpSnap
 	}
-	//     dwlta,  total size,  error
+
+	log.WithFields(log.Fields{
+		"filesystemId":    referDataset,
+		"referDataset":    referDataset,
+		"referLatestSnap": referLatestSnap,
+		"usedLatestSnap":  usedLatestSnap,
+		"foundTmpSnashot": foundTmpSnashot,
+		"latestSnap":      latestSnap,
+		"referTmpSnap":    referTmpSnap,
+		"usedTmpSnap":     usedTmpSnap,
+		"usedDataset":     usedDataset,
+		"result":          result,
+	}).Info("calculated dirty data")
+
+	//     delta,  total size,  error
 	return result, usedDataset, nil
 }
 

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -470,8 +470,8 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 	}
 	//        deleted                                + added
 	result := intDiff(referDataset, referLatestSnap) + usedLatestSnap
-	if foundTmpSnashot {
-		//        deleted                            added
+	if foundTmpSnashot && lastestSnap != tmpSnapshotName {
+		//        deleted                               added
 		result += intDiff(referDataset, referTmpSnap) + usedTmpSnap
 	}
 	//     dwlta,  total size,  error

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -476,7 +476,7 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 	}
 
 	log.WithFields(log.Fields{
-		"filesystemId":    referDataset,
+		"filesystemId":    filesystemId,
 		"referDataset":    referDataset,
 		"referLatestSnap": referLatestSnap,
 		"usedLatestSnap":  usedLatestSnap,

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -467,14 +467,6 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 			}
 		}
 	}
-	// Dirty filesystems that have been rolled back to the latest snapshot
-	// sometimes exhibit 1024 bytes used.
-	if usedLatestSnap <= 1024 {
-		usedLatestSnap = 0
-	}
-	if usedTmpSnap <= 1024 {
-		usedTmpSnap = 0
-	}
 	//     deleted                                + added
 	return intDiff(referDataset, referLatestSnap) + usedLatestSnap +
 		// deleted                            added

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -898,7 +898,7 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 	// algorithm. in this case, we need to clean up the tmp snapshot before
 	// proceeding, otherwise we risk missing filesystem changes.
 
-	dirty, _, checkLatestTmpSnapBothZeros, err := z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, latest, true)
+	dirty, _, checkLatestTmpSnapBothZeros, err := z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, snapshot, true)
 	if err != nil {
 		log.WithError(err).Error("[diff] error get dirty delta")
 		return nil, err
@@ -909,7 +909,7 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 		exec.CommandContext(ctx, "umount", tmpMnt).Run()
 		exec.CommandContext(ctx, z.zfsPath, "destroy", tmp).Run()
 
-		dirty, _, checkLatestTmpSnapBothZeros, err = z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, latest, true)
+		dirty, _, checkLatestTmpSnapBothZeros, err = z.getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemID, snapshot, true)
 		if err != nil {
 			log.WithError(err).Error("[diff] error get dirty delta (second try after tmp cleanup)")
 			return nil, err
@@ -1085,9 +1085,6 @@ func (z *zfs) Diff(filesystemID, snapshot, snapshotOrFilesystem string) ([]types
 		SnapshotID: snapshot,
 		Result:     sortedResult,
 	}
-
-	// TODO delete this verbose logging
-	log.Printf("[diff] response for %s = %s", filesystemID, sortedResult)
 
 	return sortedResult, nil
 }

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -470,7 +470,7 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 	}
 	//        deleted                                + added
 	result := intDiff(referDataset, referLatestSnap) + usedLatestSnap
-	if foundTmpSnashot && lastestSnap != tmpSnapshotName {
+	if foundTmpSnashot && latestSnap != tmpSnapshotName {
 		//        deleted                               added
 		result += intDiff(referDataset, referTmpSnap) + usedTmpSnap
 	}

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -423,6 +423,7 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 	*/
 	var referDataset, referLatestSnap, usedLatestSnap, usedDataset int64
 	var referTmpSnap, usedTmpSnap int64
+	var foundTmpSnashot bool
 	lines := strings.Split(string(o), "\n")
 	for _, line := range lines {
 		shrap := strings.Fields(line)
@@ -467,10 +468,14 @@ func (z *zfs) GetDirtyDelta(filesystemId, latestSnap string) (int64, int64, erro
 			}
 		}
 	}
-	//     deleted                                + added
-	return intDiff(referDataset, referLatestSnap) + usedLatestSnap +
-		// deleted                            added
-		intDiff(referDataset, referTmpSnap) + usedTmpSnap, usedDataset, nil
+	//        deleted                                + added
+	result := intDiff(referDataset, referLatestSnap) + usedLatestSnap
+	if foundTmpSnashot {
+		//        deleted                            added
+		result += intDiff(referDataset, referTmpSnap) + usedTmpSnap
+	}
+	//     dwlta,  total size,  error
+	return result, usedDataset, nil
 }
 
 func intDiff(a, b int64) int64 {

--- a/pkg/zfs/zfs.go
+++ b/pkg/zfs/zfs.go
@@ -469,6 +469,7 @@ func (z *zfs) getDirtyDeltaCheckLatestTmpSnapBothZeros(filesystemId, latestSnap 
 					}
 				}
 			} else if shrap[0] == FQ(z.poolName, filesystemId)+"@"+tmpSnapshotName {
+				foundTmpSnashot = true
 				// NB: tmpSnapshotName defined as package-level constant
 				if shrap[1] == "referenced" {
 					referTmpSnap, err = strconv.ParseInt(shrap[2], 10, 64)


### PR DESCRIPTION
include dirty data accounting from the tmp (fastdiff) snapshot if it exists

also, check if we're in the case where both the latest snapshots both have a zero "used" value. in this case, because zfs space accounting for "used" values for snapshots only reports blocks _unique_ to that snapshot, we'll fail to detect changes to the filesystem in the dirty data algorithm. in this case, we need to clean up the tmp snapshot before proceeding, otherwise we risk missing filesystem changes.