### PR TITLE
#733: various fixes around status messages

### DIFF
--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -481,8 +481,10 @@ func (f *FsMachine) updateEtcdAboutTransfers() error {
 		case types.TransferNextS3File:
 			pollResult.Index += 1
 			pollResult.Total += 1
-			pollResult.Size = update.Changes.Size
+			pollResult.Size += update.Changes.Size
 			pollResult.Status = update.Changes.Status
+		case types.TransferFinishedS3File:
+			pollResult.Sent += update.Changes.Sent
 		case types.TransferSent:
 			pollResult.Sent = update.Changes.Sent
 			pollResult.Status = update.Changes.Status

--- a/pkg/fsm/fsm_missing.go
+++ b/pkg/fsm/fsm_missing.go
@@ -225,6 +225,11 @@ func missingState(f *FsMachine) StateFn {
 					return backoffState
 				} else {
 					f.innerResponses <- &types.Event{Name: "created"}
+					f.snapshot(&types.Event{Name: "snapshot",
+						Args: &types.EventArgs{"metadata": map[string]string{
+							"message": "Initial commit",
+							"author":  "admin",
+						}}})
 					return activeState
 				}
 			} else {

--- a/pkg/fsm/fsm_s3_pull_initiator.go
+++ b/pkg/fsm/fsm_s3_pull_initiator.go
@@ -48,7 +48,7 @@ func s3PullInitiatorState(f *FsMachine) StateFn {
 			TransferRequestId: transferRequestId,
 			Direction:         transferRequest.Direction,
 			InitiatorNodeId:   f.state.NodeID(),
-			Index:             1,
+			Index:             0,
 			Status:            "starting",
 		},
 	}

--- a/pkg/fsm/s3.go
+++ b/pkg/fsm/s3.go
@@ -166,6 +166,7 @@ func downloadS3Bucket(f *FsMachine, svc *s3.S3, bucketName, destPath, transferRe
 	}
 	var changed bool
 	var err error
+
 	for _, prefix := range prefixes {
 		log.Debugf("[downloadS3Bucket] Pulling down objects prefixed %s", prefix)
 		changed, currentKeyVersions, err = downloadPartialS3Bucket(f, svc, bucketName, destPath, transferRequestId, prefix, currentKeyVersions)
@@ -209,6 +210,7 @@ func downloadPartialS3Bucket(f *FsMachine, svc *s3.S3, bucketName, destPath, tra
 
 				}
 			}
+
 			for _, item := range page.Versions {
 				latestMeta := currentKeyVersions[*item.Key]
 				if *item.IsLatest && latestMeta != *item.VersionId {
@@ -227,7 +229,7 @@ func downloadPartialS3Bucket(f *FsMachine, svc *s3.S3, bucketName, destPath, tra
 						return false
 					}
 					f.transferUpdates <- types.TransferUpdate{
-						Kind: types.TransferNextS3File,
+						Kind: types.TransferFinishedS3File,
 						Changes: types.TransferPollResult{
 							Status: "Pulled file successfully",
 							Sent:   *item.Size,

--- a/pkg/fsm/s3.go
+++ b/pkg/fsm/s3.go
@@ -194,7 +194,7 @@ func downloadPartialS3Bucket(f *FsMachine, svc *s3.S3, bucketName, destPath, tra
 		params.SetPrefix(prefix)
 	}
 	log.Debugf("[downloadPartialS3Bucket] params: %#v", *params)
-	downloader := s3manager.NewDownloaderWithClient(svc, func(d *s3manager.Downloader) { d.Concurrency = 20 })
+	downloader := s3manager.NewDownloaderWithClient(svc)
 	var innerError error
 	startTime := time.Now()
 	var sent int64

--- a/pkg/types/fsm_types.go
+++ b/pkg/types/fsm_types.go
@@ -35,6 +35,7 @@ const (
 	TransferProgress
 	TransferIncrementIndex
 	TransferNextS3File
+	TransferFinishedS3File
 	TransferSent
 	TransferFinished
 	TransferStatus


### PR DESCRIPTION
Fixes #733 - previously in the CLI the way we're doing status updates meant that we had more files done than the total, and thus it would never complete (files completed never equalled the total)...this might also be the case for something polling the api, and for the thing listening to commits, but not sure.

This PR:
- makes status updates more reliable, also gives you a running update of how much time is left and how much has been downloaded so far
- makes an initial commit on dot creation so that we can do resets
- times out if a s3 pull gets stuck during a transfer