### PR TITLE
720 pushpeer report bytes

### DIFF
--- a/pkg/fsm/fsm_push_peer.go
+++ b/pkg/fsm/fsm_push_peer.go
@@ -99,12 +99,12 @@ func pushPeerState(f *FsMachine) StateFn {
 					bytes := b.(int64)
 					now := time.Now()
 					seconds := now.Sub(start).Seconds()
-					mb := bytes / 1048576
+					mb := float64(bytes) / 1048576
 					if seconds > 0 {
 						mbPerSecond := (float64(bytes) / seconds) / 1048576
-						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %.3f MiB so far, %.3f MiB/sec", mb, mbPerSecond))
 					} else {
-						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far", mb))
+						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %.3f MiB so far", mb))
 					}
 				} else {
 					f.transitionedTo("pushPeerState", "running")

--- a/pkg/fsm/fsm_push_peer.go
+++ b/pkg/fsm/fsm_push_peer.go
@@ -88,12 +88,20 @@ func pushPeerState(f *FsMachine) StateFn {
 	}
 
 	go func() {
+		start := time.Now()
 		for {
 			select {
-			case <-receiveProgress:
+			case b := <-receiveProgress:
 				//log.Printf(
 				//	"[pushPeerState] resetting timer because some progress was made (%d bytes)", b,
 				//)
+				bytes := b.(int64)
+				now := time.Now()
+				seconds := now.Sub(start).Seconds()
+				mb := bytes / 1048576
+				mbPerSecond := (float64(bytes) / seconds) / 1048576
+				f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+
 				reset()
 			case <-finished:
 				return

--- a/pkg/fsm/fsm_push_peer.go
+++ b/pkg/fsm/fsm_push_peer.go
@@ -95,15 +95,19 @@ func pushPeerState(f *FsMachine) StateFn {
 				//log.Printf(
 				//	"[pushPeerState] resetting timer because some progress was made (%d bytes)", b,
 				//)
-				bytes := b.(int64)
-				now := time.Now()
-				seconds := now.Sub(start).Seconds()
-				mb := bytes / 1048576
-				if seconds > 0 {
-					mbPerSecond := (float64(bytes) / seconds) / 1048576
-					f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+				if b != nil {
+					bytes := b.(int64)
+					now := time.Now()
+					seconds := now.Sub(start).Seconds()
+					mb := bytes / 1048576
+					if seconds > 0 {
+						mbPerSecond := (float64(bytes) / seconds) / 1048576
+						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+					} else {
+						f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far", mb))
+					}
 				} else {
-					f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far", mb))
+					f.transitionedTo("pushPeerState", "running")
 				}
 
 				reset()

--- a/pkg/fsm/fsm_push_peer.go
+++ b/pkg/fsm/fsm_push_peer.go
@@ -99,8 +99,12 @@ func pushPeerState(f *FsMachine) StateFn {
 				now := time.Now()
 				seconds := now.Sub(start).Seconds()
 				mb := bytes / 1048576
-				mbPerSecond := (float64(bytes) / seconds) / 1048576
-				f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+				if seconds > 0 {
+					mbPerSecond := (float64(bytes) / seconds) / 1048576
+					f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far, %.3f MiB/sec", mb, mbPerSecond))
+				} else {
+					f.transitionedTo("pushPeerState", fmt.Sprintf("running: %d MiB so far", mb))
+				}
 
 				reset()
 			case <-finished:


### PR DESCRIPTION
Report the bytes transferred so far (and the rate) in the status when "push peer" (eg, receiving a push) state. This is to support issue https://github.com/dotmesh-io/frontend-ng/issues/625