### PR TITLE
Frontend ng 635 folder based navigation

### DIFF
--- a/cmd/dotmesh-server/s3_handlers.go
+++ b/cmd/dotmesh-server/s3_handlers.go
@@ -321,11 +321,8 @@ func (s *S3Handler) listBucket(resp http.ResponseWriter, req *http.Request, name
 		mountPath := (*e.Args)["mount-path"].(string)
 
 		// what path are we starting at
-		subPath := req.URL.Query().Get("path")
-		path := mountPath + "/__default__"
-		if subPath != "" {
-			path += "/" + subPath
-		}
+		path := req.URL.Query().Get("path")
+		base := mountPath + "/__default__"
 
 		// setting default limit to 100 files
 		var limit int64 = 100
@@ -362,6 +359,7 @@ func (s *S3Handler) listBucket(resp http.ResponseWriter, req *http.Request, name
 		}
 
 		listFileRequest := types.ListFileRequest{
+			Base:               base,
 			Path:               path,
 			Limit:              limit,
 			Page:               page,

--- a/pkg/fsm/fsm_s3_push_initiator.go
+++ b/pkg/fsm/fsm_s3_push_initiator.go
@@ -69,7 +69,13 @@ func s3PushInitiatorState(f *FsMachine) StateFn {
 		}
 		// list everything in the main directory
 		pathToMount := fmt.Sprintf("%s/__default__", mountPoint)
-		paths, dirSize, _, err := GetKeysForDirLimit(pathToMount, "", 0)
+
+		listKeysQuery := types.ListFileQuery{
+			Limit:        0,
+			Offset:       0,
+			NonRecursive: false,
+		}
+		paths, dirSize, _, err := GetKeysForDirLimit(pathToMount, "", listKeysQuery)
 		if err != nil {
 			f.sendEvent(&types.EventArgs{"err": err, "path": pathToMount}, "cant-get-keys-for-directory", "")
 			return backoffState

--- a/pkg/fsm/fsm_s3_push_initiator.go
+++ b/pkg/fsm/fsm_s3_push_initiator.go
@@ -72,8 +72,8 @@ func s3PushInitiatorState(f *FsMachine) StateFn {
 
 		listKeysRequest := types.ListFileRequest{
 			Base:               pathToMount,
-			Path:               "",
-			Limit:              0,
+			Prefix:             "",
+			MaxKeys:            0,
 			Page:               0,
 			Recursive:          true,
 			IncludeDirectories: false,

--- a/pkg/fsm/fsm_s3_push_initiator.go
+++ b/pkg/fsm/fsm_s3_push_initiator.go
@@ -71,7 +71,8 @@ func s3PushInitiatorState(f *FsMachine) StateFn {
 		pathToMount := fmt.Sprintf("%s/__default__", mountPoint)
 
 		listKeysRequest := types.ListFileRequest{
-			Path:               pathToMount,
+			Base:               pathToMount,
+			Path:               "",
 			Limit:              0,
 			Page:               0,
 			Recursive:          true,

--- a/pkg/fsm/s3.go
+++ b/pkg/fsm/s3.go
@@ -83,15 +83,15 @@ func writeS3Metadata(path string, versions map[string]string) error {
 // we do this so we can pick the correct page of results
 // based on the limit and page query params for a recursive request
 func GetAllKeysForDir(query types.ListFileRequest) (results []types.ListFileItem, err error) {
-	readDirectoryPath := query.Base + "/" + query.Path
+	readDirectoryPath := query.Base + "/" + query.Prefix
 	fileNames, err := ioutil.ReadDir(readDirectoryPath)
 	if err != nil {
 		return nil, err
 	}
 
-	prependPath := query.Path
+	prependPath := query.Prefix
 
-	if query.Path != "" {
+	if query.Prefix != "" {
 		prependPath = prependPath + "/"
 	}
 
@@ -135,8 +135,8 @@ func GetAllKeysForDir(query types.ListFileRequest) (results []types.ListFileItem
 		for _, directoryInfo := range directories {
 			directoryListRequest := types.ListFileRequest{
 				Base:               query.Base,
-				Path:               prependPath + directoryInfo.Name(),
-				Limit:              0,
+				Prefix:             prependPath + directoryInfo.Name(),
+				MaxKeys:            0,
 				Page:               0,
 				Recursive:          true,
 				IncludeDirectories: query.IncludeDirectories,
@@ -164,9 +164,9 @@ func GetKeysForDirLimit(query types.ListFileRequest) (results types.ListFileResp
 	results.TotalCount = int64(len(items))
 	var page []types.ListFileItem
 
-	if query.Limit > 0 {
-		startIndex := query.Page * query.Limit
-		endIndex := startIndex + query.Limit
+	if query.MaxKeys > 0 {
+		startIndex := query.Page * query.MaxKeys
+		endIndex := startIndex + query.MaxKeys
 
 		if endIndex > results.TotalCount {
 			endIndex = results.TotalCount

--- a/pkg/fsm/s3.go
+++ b/pkg/fsm/s3.go
@@ -162,7 +162,24 @@ func GetKeysForDirLimit(query types.ListFileRequest) (results types.ListFileResp
 	}
 
 	results.TotalCount = int64(len(items))
-	results.Items = items
+	var page []types.ListFileItem
+
+	if query.Limit > 0 {
+		startIndex := query.Page * query.Limit
+		endIndex := startIndex + query.Limit
+
+		if endIndex > results.TotalCount {
+			endIndex = results.TotalCount
+		}
+
+		for i := startIndex; i < endIndex; i++ {
+			page = append(page, items[i])
+		}
+
+		results.Items = page
+	} else {
+		results.Items = items
+	}
 
 	return results, nil
 }

--- a/pkg/fsm/s3_test.go
+++ b/pkg/fsm/s3_test.go
@@ -34,8 +34,8 @@ func TestGetKeysForDirLimitRecursiveLimit3(t *testing.T) {
 
 	listKeysRequest := types.ListFileRequest{
 		Base:               tDir,
-		Path:               "",
-		Limit:              3,
+		Prefix:             "",
+		MaxKeys:            3,
 		Page:               0,
 		Recursive:          true,
 		IncludeDirectories: false,
@@ -61,8 +61,8 @@ func TestGetKeysForDirLimitRecursiveLimitNone(t *testing.T) {
 	defer os.RemoveAll(tDir)
 	listKeysRequest := types.ListFileRequest{
 		Base:               tDir,
-		Path:               "",
-		Limit:              0,
+		Prefix:             "",
+		MaxKeys:            0,
 		Page:               0,
 		Recursive:          true,
 		IncludeDirectories: false,
@@ -88,8 +88,8 @@ func TestGetKeysForDirLimitNotRecursiveLimitNone(t *testing.T) {
 	defer os.RemoveAll(tDir)
 	listKeysRequest := types.ListFileRequest{
 		Base:               tDir,
-		Path:               "",
-		Limit:              0,
+		Prefix:             "",
+		MaxKeys:            0,
 		Page:               0,
 		Recursive:          false,
 		IncludeDirectories: true,
@@ -118,8 +118,8 @@ func TestGetKeysForDirLimitSubPath(t *testing.T) {
 	//defer os.RemoveAll(tDir)
 	listKeysRequest := types.ListFileRequest{
 		Base:               tDir,
-		Path:               "2",
-		Limit:              0,
+		Prefix:             "2",
+		MaxKeys:            0,
 		Page:               0,
 		Recursive:          false,
 		IncludeDirectories: false,
@@ -148,8 +148,8 @@ func TestGetKeysForDirLimitSubPathLimit2Page2(t *testing.T) {
 	//defer os.RemoveAll(tDir)
 	listKeysRequest := types.ListFileRequest{
 		Base:               tDir,
-		Path:               "2",
-		Limit:              2,
+		Prefix:             "2",
+		MaxKeys:            2,
 		Page:               2,
 		Recursive:          false,
 		IncludeDirectories: false,

--- a/pkg/fsm/s3_test.go
+++ b/pkg/fsm/s3_test.go
@@ -14,10 +14,10 @@ func setupTestFiles() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for x := 1; x <= 10; x++ {
+	for x := 0; x < 10; x++ {
 		dir := fmt.Sprintf("%s/%d", tDir, x)
 		os.Mkdir(dir, os.ModePerm)
-		for y := 1; y <= 10; y++ {
+		for y := 0; y < 10; y++ {
 			file := fmt.Sprintf("%s/%d.txt", dir, y)
 			ioutil.WriteFile(file, []byte("X"), os.ModePerm)
 		}
@@ -131,8 +131,8 @@ func TestGetKeysForDirLimitSubPath(t *testing.T) {
 	if len(listKeysResponse.Items) != 10 {
 		t.Errorf("expected to get 10 files returned, got: %d", len(listKeysResponse.Items))
 	}
-	if listKeysResponse.Items[0].Key != "2/1.txt" {
-		t.Errorf("expected first item to be 2/1.txt: %s", listKeysResponse.Items[0].Key)
+	if listKeysResponse.Items[0].Key != "2/0.txt" {
+		t.Errorf("expected first item to be 2/0.txt: %s", listKeysResponse.Items[0].Key)
 	}
 	if listKeysResponse.TotalCount != 10 {
 		t.Errorf("expected total items to be 10: %d", listKeysResponse.TotalCount)
@@ -161,8 +161,8 @@ func TestGetKeysForDirLimitSubPathLimit2Page2(t *testing.T) {
 	if len(listKeysResponse.Items) != 2 {
 		t.Errorf("expected to get 2 files returned, got: %d", len(listKeysResponse.Items))
 	}
-	if listKeysResponse.Items[0].Key != "2/5.txt" {
-		t.Errorf("expected first item to be 2/5.txt: %s", listKeysResponse.Items[0].Key)
+	if listKeysResponse.Items[0].Key != "2/4.txt" {
+		t.Errorf("expected first item to be 2/4.txt: %s", listKeysResponse.Items[0].Key)
 	}
 	if listKeysResponse.TotalCount != 10 {
 		t.Errorf("expected total items to be 10: %d", listKeysResponse.TotalCount)

--- a/pkg/fsm/s3_test.go
+++ b/pkg/fsm/s3_test.go
@@ -1,70 +1,171 @@
 package fsm
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/dotmesh-io/dotmesh/pkg/types"
 )
 
-func TestgetKeysForDirLimit3(t *testing.T) {
+func setupTestFiles() (string, error) {
 	tDir, err := ioutil.TempDir(os.TempDir(), "")
 	if err != nil {
-		t.Fatalf("failed to create dir: %s", err)
+		return "", err
 	}
-	defer os.RemoveAll(tDir)
-
-	ioutil.WriteFile(filepath.Join(tDir, "root-1.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-2.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-3.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-4.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-1.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-2.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-3.txt"), []byte("X"), os.ModePerm)
-
-	listKeysQuery := types.ListFileQuery{
-		Limit:        3,
-		Offset:       0,
-		NonRecursive: false,
+	for x := 1; x <= 10; x++ {
+		dir := fmt.Sprintf("%s/%d", tDir, x)
+		os.Mkdir(dir, os.ModePerm)
+		for y := 1; y <= 10; y++ {
+			file := fmt.Sprintf("%s/%d.txt", dir, y)
+			ioutil.WriteFile(file, []byte("X"), os.ModePerm)
+		}
 	}
-	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", listKeysQuery)
-	if err != nil {
-		t.Fatalf("failed to get dir limit: %s", err)
-	}
-	if len(files) != 3 {
-		t.Errorf("expected to get 3 files returned, got: %d", len(files))
-	}
-	t.Logf("files: %d, files count: %d, size: %d", len(files), dirFilesCount, size)
+	return tDir, nil
 }
 
-func TestgetKeysForDirLimitNoLimit(t *testing.T) {
-	tDir, err := ioutil.TempDir(os.TempDir(), "")
+func TestGetKeysForDirLimitRecursiveLimit3(t *testing.T) {
+	tDir, err := setupTestFiles()
 	if err != nil {
 		t.Fatalf("failed to create dir: %s", err)
 	}
 	defer os.RemoveAll(tDir)
 
-	ioutil.WriteFile(filepath.Join(tDir, "root-1.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-2.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-3.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "root-4.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-1.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-2.txt"), []byte("X"), os.ModePerm)
-	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-3.txt"), []byte("X"), os.ModePerm)
-
-	listKeysQuery := types.ListFileQuery{
-		Limit:        0,
-		Offset:       0,
-		NonRecursive: false,
+	listKeysRequest := types.ListFileRequest{
+		Base:               tDir,
+		Path:               "",
+		Limit:              3,
+		Page:               0,
+		Recursive:          true,
+		IncludeDirectories: false,
 	}
-	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", listKeysQuery)
+	listKeysResponse, err := GetKeysForDirLimit(listKeysRequest)
 	if err != nil {
 		t.Fatalf("failed to get dir limit: %s", err)
 	}
-	if len(files) != 7 {
-		t.Errorf("expected to get 7 files returned, got: %d", len(files))
+	if len(listKeysResponse.Items) != 3 {
+		t.Errorf("expected to get 3 files returned, got: %d", len(listKeysResponse.Items))
 	}
-	t.Logf("files: %d, files count: %d, size: %d", len(files), dirFilesCount, size)
+	if listKeysResponse.TotalCount != 100 {
+		t.Errorf("expected total items to be 100: %d", listKeysResponse.TotalCount)
+	}
+	t.Logf("files: %d, total files count: %d", len(listKeysResponse.Items), listKeysResponse.TotalCount)
+}
+
+func TestGetKeysForDirLimitRecursiveLimitNone(t *testing.T) {
+	tDir, err := setupTestFiles()
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	defer os.RemoveAll(tDir)
+	listKeysRequest := types.ListFileRequest{
+		Base:               tDir,
+		Path:               "",
+		Limit:              0,
+		Page:               0,
+		Recursive:          true,
+		IncludeDirectories: false,
+	}
+	listKeysResponse, err := GetKeysForDirLimit(listKeysRequest)
+	if err != nil {
+		t.Fatalf("failed to get dir limit: %s", err)
+	}
+	if len(listKeysResponse.Items) != 100 {
+		t.Errorf("expected to get 100 files returned, got: %d", len(listKeysResponse.Items))
+	}
+	if listKeysResponse.TotalCount != 100 {
+		t.Errorf("expected total items to be 100: %d", listKeysResponse.TotalCount)
+	}
+	t.Logf("files: %d, total files count: %d", len(listKeysResponse.Items), listKeysResponse.TotalCount)
+}
+
+func TestGetKeysForDirLimitNotRecursiveLimitNone(t *testing.T) {
+	tDir, err := setupTestFiles()
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	defer os.RemoveAll(tDir)
+	listKeysRequest := types.ListFileRequest{
+		Base:               tDir,
+		Path:               "",
+		Limit:              0,
+		Page:               0,
+		Recursive:          false,
+		IncludeDirectories: true,
+	}
+	listKeysResponse, err := GetKeysForDirLimit(listKeysRequest)
+	if err != nil {
+		t.Fatalf("failed to get dir limit: %s", err)
+	}
+	if len(listKeysResponse.Items) != 10 {
+		t.Errorf("expected to get 10 folders returned, got: %d", len(listKeysResponse.Items))
+	}
+	if listKeysResponse.Items[0].Directory != true {
+		t.Errorf("expected first item to be a directory")
+	}
+	if listKeysResponse.TotalCount != 10 {
+		t.Errorf("expected total items to be 10: %d", listKeysResponse.TotalCount)
+	}
+	t.Logf("files: %d, total files count: %d", len(listKeysResponse.Items), listKeysResponse.TotalCount)
+}
+
+func TestGetKeysForDirLimitSubPath(t *testing.T) {
+	tDir, err := setupTestFiles()
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	//defer os.RemoveAll(tDir)
+	listKeysRequest := types.ListFileRequest{
+		Base:               tDir,
+		Path:               "2",
+		Limit:              0,
+		Page:               0,
+		Recursive:          false,
+		IncludeDirectories: false,
+	}
+	listKeysResponse, err := GetKeysForDirLimit(listKeysRequest)
+	if err != nil {
+		t.Fatalf("failed to get dir limit: %s", err)
+	}
+	if len(listKeysResponse.Items) != 10 {
+		t.Errorf("expected to get 10 files returned, got: %d", len(listKeysResponse.Items))
+	}
+	if listKeysResponse.Items[0].Key != "2/1.txt" {
+		t.Errorf("expected first item to be 2/1.txt: %s", listKeysResponse.Items[0].Key)
+	}
+	if listKeysResponse.TotalCount != 10 {
+		t.Errorf("expected total items to be 10: %d", listKeysResponse.TotalCount)
+	}
+	t.Logf("files: %d, total files count: %d", len(listKeysResponse.Items), listKeysResponse.TotalCount)
+}
+
+func TestGetKeysForDirLimitSubPathLimit2Page2(t *testing.T) {
+	tDir, err := setupTestFiles()
+	if err != nil {
+		t.Fatalf("failed to create dir: %s", err)
+	}
+	//defer os.RemoveAll(tDir)
+	listKeysRequest := types.ListFileRequest{
+		Base:               tDir,
+		Path:               "2",
+		Limit:              2,
+		Page:               2,
+		Recursive:          false,
+		IncludeDirectories: false,
+	}
+	listKeysResponse, err := GetKeysForDirLimit(listKeysRequest)
+	if err != nil {
+		t.Fatalf("failed to get dir limit: %s", err)
+	}
+	if len(listKeysResponse.Items) != 2 {
+		t.Errorf("expected to get 2 files returned, got: %d", len(listKeysResponse.Items))
+	}
+	if listKeysResponse.Items[0].Key != "2/5.txt" {
+		t.Errorf("expected first item to be 2/5.txt: %s", listKeysResponse.Items[0].Key)
+	}
+	if listKeysResponse.TotalCount != 10 {
+		t.Errorf("expected total items to be 10: %d", listKeysResponse.TotalCount)
+	}
+	t.Logf("files: %d, total files count: %d", len(listKeysResponse.Items), listKeysResponse.TotalCount)
 }

--- a/pkg/fsm/s3_test.go
+++ b/pkg/fsm/s3_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dotmesh-io/dotmesh/pkg/types"
 )
 
 func TestgetKeysForDirLimit3(t *testing.T) {
@@ -22,7 +24,12 @@ func TestgetKeysForDirLimit3(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-2.txt"), []byte("X"), os.ModePerm)
 	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-3.txt"), []byte("X"), os.ModePerm)
 
-	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", 3)
+	listKeysQuery := types.ListFileQuery{
+		Limit:        3,
+		Offset:       0,
+		NonRecursive: false,
+	}
+	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", listKeysQuery)
 	if err != nil {
 		t.Fatalf("failed to get dir limit: %s", err)
 	}
@@ -47,7 +54,12 @@ func TestgetKeysForDirLimitNoLimit(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-2.txt"), []byte("X"), os.ModePerm)
 	ioutil.WriteFile(filepath.Join(tDir, "/dir/level-1-3.txt"), []byte("X"), os.ModePerm)
 
-	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", 0)
+	listKeysQuery := types.ListFileQuery{
+		Limit:        0,
+		Offset:       0,
+		NonRecursive: false,
+	}
+	files, dirFilesCount, size, err := GetKeysForDirLimit(tDir, "/", listKeysQuery)
 	if err != nil {
 		t.Fatalf("failed to get dir limit: %s", err)
 	}

--- a/pkg/types/fsm_types.go
+++ b/pkg/types/fsm_types.go
@@ -25,6 +25,15 @@ type OutputFile struct {
 	Response          chan *Event
 }
 
+// Use to specify the limit and path
+// for a GetKeysForDirLimit query in fsm/s3
+// this means we can support paging in the list of files
+type ListFileQuery struct {
+	Limit        int64 // how many files per page
+	Offset       int64 // what page we are viewing - we start listing at Offset * Limit
+	NonRecursive bool  // meaning we only want to list files at the given subpath and not recurse
+}
+
 type TransferUpdateKind int
 
 const (

--- a/pkg/types/fsm_types.go
+++ b/pkg/types/fsm_types.go
@@ -28,7 +28,8 @@ type OutputFile struct {
 
 // request when calling s3.GetKeysForDirLimit
 type ListFileRequest struct {
-	Path               string // what is the path we are listing
+	Base               string // the root of the dot we are listing
+	Path               string // the sub path we are listing
 	Limit              int64  // limit the number of files we get in the response
 	Page               int64  // what page we are viewing - we start listing at Page * Limit
 	Recursive          bool   // do we want to recurse into folders or just look at the given path

--- a/pkg/types/fsm_types.go
+++ b/pkg/types/fsm_types.go
@@ -29,8 +29,8 @@ type OutputFile struct {
 // request when calling s3.GetKeysForDirLimit
 type ListFileRequest struct {
 	Base               string // the root of the dot we are listing
-	Path               string // the sub path we are listing
-	Limit              int64  // limit the number of files we get in the response
+	Prefix             string // the sub path we are listing
+	MaxKeys            int64  // limit the number of files we get in the response
 	Page               int64  // what page we are viewing - we start listing at Page * Limit
 	Recursive          bool   // do we want to recurse into folders or just look at the given path
 	IncludeDirectories bool   // do we want directories to be included in the result or just files?
@@ -43,10 +43,10 @@ type ListFileResponse struct {
 
 // a single item in the results from s3.GetKeysForDirLimit
 type ListFileItem struct {
-	Key          string // the full path to the item (including folders)
-	LastModified time.Time
-	Size         int64
-	Directory    bool // is this item a directory or a file
+	Key          string    `json:"key"` // the full path to the item (including folders)
+	LastModified time.Time `json:"last_modified"`
+	Size         int64     `json:"size"`
+	Directory    bool      `json:"directory"` // is this item a directory or a file
 }
 
 type TransferUpdateKind int

--- a/pkg/types/fsm_types.go
+++ b/pkg/types/fsm_types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 )
 
 // InputFile is used to write files to the disk on the local node.
@@ -25,13 +26,26 @@ type OutputFile struct {
 	Response          chan *Event
 }
 
-// Use to specify the limit and path
-// for a GetKeysForDirLimit query in fsm/s3
-// this means we can support paging in the list of files
-type ListFileQuery struct {
-	Limit        int64 // how many files per page
-	Offset       int64 // what page we are viewing - we start listing at Offset * Limit
-	NonRecursive bool  // meaning we only want to list files at the given subpath and not recurse
+// request when calling s3.GetKeysForDirLimit
+type ListFileRequest struct {
+	Path               string // what is the path we are listing
+	Limit              int64  // limit the number of files we get in the response
+	Page               int64  // what page we are viewing - we start listing at Page * Limit
+	Recursive          bool   // do we want to recurse into folders or just look at the given path
+	IncludeDirectories bool   // do we want directories to be included in the result or just files?
+}
+
+type ListFileResponse struct {
+	Items      []ListFileItem
+	TotalCount int64
+}
+
+// a single item in the results from s3.GetKeysForDirLimit
+type ListFileItem struct {
+	Key          string // the full path to the item (including folders)
+	LastModified time.Time
+	Size         int64
+	Directory    bool // is this item a directory or a file
 }
 
 type TransferUpdateKind int


### PR DESCRIPTION
Allows the S3 api to list bucket files from a certain path.

This is driven by the `path` query parameter - if we pass a file key as part of the url (e.g. `/s3/{namespace}:{name}/{key:.*}`) it means we are download the file at that key.

The following query parameters are supported:

 * `path` - at what sub path are we wanting to list files (blank string means the root of the dot)
 * `limit` - what is the maximum number of results we want back
 * `page` - allows for paging through results - page is combined with limit to know what range of the results to return
 * `nonRecursive` - means don't descend into folders - only return items directly in the given path
 * `includeDirectories` - means include directories in the results

This is how to get a list of all files in the dot (i.e. the currently implementation):
 * `path=`
 * `limit=0`
 * `page=0`
 * `nonRecursive=`
 * `includeDirectories=`

The result will also include a `TotalResults` property - this allows the frontend to know how many pages of results there are in total so it can show a pager UI.

There are additional unit tests to cover what the frontend is expecting.

