### PR TITLE
FIX: pass the server config down to the in memory state

### DIFF
--- a/cmd/dotmesh-server/controller.go
+++ b/cmd/dotmesh-server/controller.go
@@ -97,6 +97,7 @@ func NewInMemoryState(config Opts) *InMemoryState {
 	}
 
 	s := &InMemoryState{
+		serverConfig:             config.Config,
 		opts:                     config,
 		filesystems:              make(map[string]fsm.FSM),
 		filesystemsLock:          &sync.RWMutex{},


### PR DESCRIPTION
Pass the server config through to the in memory state